### PR TITLE
Trigger Rabbit Broker only on new Rabbit releases

### DIFF
--- a/pipelines/rabbitmq.yml
+++ b/pipelines/rabbitmq.yml
@@ -105,8 +105,11 @@ jobs:
   plan:
   - do:
     - get: pipelines-repo
-    - get: cf-rabbitmq-multitenant-broker-release
+    - get: cf-rabbitmq-release
+      passed:
+        - fetch-rabbitmq
       trigger: true
+    - get: cf-rabbitmq-multitenant-broker-release
     - task: process-rabbitmq-broker
       config:
         platform: linux
@@ -160,10 +163,6 @@ jobs:
     - get: cf-rabbitmq-release
       passed:
         - fetch-rabbitmq
-      trigger: true
-    - get: cf-rabbitmq-multitenant-broker-release
-      passed:
-        - fetch-rabbitmq-broker
       trigger: true
     - get: cf-rabbitmq-smoke-tests-release
     - task: process-rabbitmq-smoke-tests
@@ -220,10 +219,6 @@ jobs:
       passed:
         - fetch-rabbitmq
       trigger: true
-    - get: cf-rabbitmq-multitenant-broker-release
-      passed:
-        - fetch-rabbitmq-broker
-      trigger: true
     - get: cf-cli-release
     - task: process-cf-cli
       config:
@@ -278,10 +273,6 @@ jobs:
     - get: cf-rabbitmq-release
       passed:
         - fetch-rabbitmq
-      trigger: true
-    - get: cf-rabbitmq-multitenant-broker-release
-      passed:
-        - fetch-rabbitmq-broker
       trigger: true
     - get: routing-release
     - task: process-routing
@@ -338,10 +329,6 @@ jobs:
       passed:
         - fetch-rabbitmq
       trigger: true
-    - get: cf-rabbitmq-multitenant-broker-release
-      passed:
-        - fetch-rabbitmq-broker
-      trigger: true
     - get: bpm-release
     - task: process-bpm
       config:
@@ -396,10 +383,6 @@ jobs:
     - get: cf-rabbitmq-release
       passed:
         - fetch-rabbitmq
-      trigger: true
-    - get: cf-rabbitmq-multitenant-broker-release
-      passed:
-        - fetch-rabbitmq-broker
       trigger: true
     - get: stemcell
       params:

--- a/scripts/process-cf-cli.sh
+++ b/scripts/process-cf-cli.sh
@@ -8,13 +8,13 @@ CF_CLI_OUTPUT=$2
 CF_CLI_VERSION=$(cat ${CF_CLI_SOURCE}/version)
 
 # Process CF CLI
-echo Processing CF CLI ${CF_CLI_VERSION} Linux client (RPM installer)
+echo "Processing CF CLI ${CF_CLI_VERSION} Linux client (RPM installer)"
 curl --silent --retry 5 -Lo ${CF_CLI_OUTPUT}/cf-cli-installer_${CF_CLI_VERSION}_x86-64.rpm "https://packages.cloudfoundry.org/stable?release=redhat64&version=${CF_CLI_VERSION}&source=github-rel"
-echo Processing CF CLI ${CF_CLI_VERSION} Windows client (installer)
+echo "Processing CF CLI ${CF_CLI_VERSION} Windows client (installer)"
 curl --silent --retry 5 -Lo ${CF_CLI_OUTPUT}/cf-cli-installer_${CF_CLI_VERSION}_winx64.zip "https://packages.cloudfoundry.org/stable?release=windows64&version=${CF_CLI_VERSION}&source=github-rel"
-echo Processing CF CLI ${CF_CLI_VERSION} Windows client (standalone)
+echo "Processing CF CLI ${CF_CLI_VERSION} Windows client (standalone)"
 curl --silent --retry 5 -Lo ${CF_CLI_OUTPUT}/cf-cli_${CF_CLI_VERSION}_winx64.zip "https://packages.cloudfoundry.org/stable?release=windows64-exe&version=${CF_CLI_VERSION}&source=github-rel"
 if [[ -f ${CF_CLI_SOURCE}/body ]]; then
-  echo Processing CF CLI ${CF_CLI_VERSION} release notes
+  echo "Processing CF CLI ${CF_CLI_VERSION} release notes"
   cp ${CF_CLI_SOURCE}/body ${CF_CLI_OUTPUT}/cf-cli-installer_${CF_CLI_VERSION}-release.md
 fi


### PR DESCRIPTION
Also added missing double-quotes in the process-cf-cli.sh script.

Fixes issue #36 