### PR TITLE
Check Bosh-deployment master branch

### DIFF
--- a/pipelines/director.yml
+++ b/pipelines/director.yml
@@ -16,7 +16,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/bosh-deployment.git
-    tag_filter: "*"
+    branch: master
 - name: bosh-cli-release
   type: github-release
   source:


### PR DESCRIPTION
They will not tag/release anymore the repo so we need to go back to
checking master