### PR TITLE
Setup Common Buildpack Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-.idea
+creds.yml
+credential.yml
 credentials.yml
+private.yml

--- a/high-pipelines/buildpacks/README.md
+++ b/high-pipelines/buildpacks/README.md
@@ -1,0 +1,68 @@
+# Buildpacks pipeline
+
+This pipeline can be used to update and build a Buildpack Bosh release. It is used
+to bump the included buildpack blob to the latest version and create a new bosh
+release for it.
+
+The pipeline is triggered from a new buildpack artifact discovered in Nexus.
+
+Outputs will be the updated Buildpack Bosh release repository and the new Bosh release
+uploaded to Nexus.
+
+## Setup
+
+### Common settings
+
+#### Credentials
+
+Currently the `reconfigure-pipeline` script looks for a file called `creds.yml`
+in the pipeline folder. This file needs to contain the following list of credentials
+for the pipeline to run successfully. These credentials are common for all buildpacks
+pipelines.
+
+* `bot-email`: Email used for the git commit author.
+* `bot-user`: Name used for the git commit author.
+* `bucket-access-key`: Buildpack Bosh release blobstore `access_key_id` which will
+  be place in the `config/private.yml` file.
+* `bucket-secret-key`: Buildpack Bosh release blobstore `secret_access_key` which
+  will be place in the `config/private.yml` file.
+* `buildpack-git-username`: Git user for doing the push on the repository.
+* `buildpack-git-password`: Git user password for doing the push on the repository.
+* `nexus-username`: Nexus user for accessing/uploading to the repository.
+* `nexus-password`: Nexus password for accessing/uploading to the repository.
+* `slack-webhook`: Slack webhook for notifications.
+
+#### Common parameters
+
+Common parameters are stored in the `vars-common.yml` file and include the following:
+
+* `tasks-repository`: Git repository containing our common pipeline tasks.
+* `tasks-branch`: Git repository branch containing our common pipeline tasks.
+* `nexus-url`: The Nexus server URL for fetching the buildpack artifact and uploading
+  the bosh release.
+* `nexus-debug`: Can be set to `true` to enable debugging of the [nexus-resource](https://github.com/trecnoc/nexus-resource).
+* `nexus-repository`: The Nexus repository containing the buildpacks and bosh releases.
+* `nexus-buildpack-group`: The Nexus repository group containing the buildpacks.
+* `nexus-bosh-group`: The Nexus repository group for uploading the Bosh releases.
+
+### Individual pipeline
+
+To deploy a new Buildpack pipeline simply create a `vars-${pipeline-name}.yml`
+with the required parameters for the Buildpack.
+
+* `nexus-buildpack-regexp`: The regular expression used to find a new version of
+  a buildpack in Nexus. This regular expression must contain one capture group which
+  is used to extract the version (see [nexus-resource](https://github.com/trecnoc/nexus-resource)).
+* `nexus-bosh-regexp`: The regular expression used to find a new version of the
+  bosh release of the buildpack in Nexus. This regular expression must contain
+  one capture group which is used to extract the version (see [nexus-resource](https://github.com/trecnoc/nexus-resource)).
+* `buildpack-git-repository`: Buidpack Bosh release Git repository (https only).
+* `buildpack-git-branch`: Buidpack Bosh release Git repository branch.
+* `buildpack-blob-name`: Blob name in the Bosh release, this corresponds to the
+  prefix of the blob path.
+* `buildpack-blob-regexp`: Regex to find the matching buildpack blob (based on
+  the path) and extract the current version.
+
+And then to deploy the pipeline run:
+
+`./reconfigure-pipeline <FLY TARGET> <PIPELINE NAME>`

--- a/high-pipelines/buildpacks/pipeline.yml
+++ b/high-pipelines/buildpacks/pipeline.yml
@@ -1,0 +1,105 @@
+---
+resource_types:
+- name: slack-notifier
+  type: docker-image
+  source:
+    repository: mockersf/concourse-slack-notifier
+- name: nexus
+  type: docker-image
+  source:
+    repository: trecnoc/nexus-resource
+    tag: latest
+
+resources:
+- name: pipeline-tasks
+  type: git
+  source:
+    uri: ((tasks-repository))
+    branch: ((tasks-branch))
+- name: buildpack-artifact
+  type: nexus
+  source:
+    url: ((nexus-url))
+    username: ((nexus-username))
+    password: ((nexus-password))
+    repository: ((nexus-repository))
+    group: ((nexus-buildpack-group))
+    regexp: ((nexus-buildpack-regexp))
+    debug: ((nexus-debug))
+- name: buildpack-repo
+  type: git
+  source:
+    uri: ((buildpack-git-repository))
+    branch: ((buildpack-git-branch))
+    username: ((buildpack-git-username))
+    password: ((buildpack-git-password))
+- name: bosh-release
+  type: nexus
+  source:
+    url: ((nexus-url))
+    username: ((nexus-username))
+    password: ((nexus-password))
+    repository: ((nexus-repository))
+    group: ((nexus-bosh-group))
+    regexp: ((nexus-bosh-regexp))
+- name: notify
+  type: slack-notifier
+  source:
+    url: ((slack-webhook))
+
+jobs:
+- name: create-bosh-release
+  build_log_retention:
+    builds: 10
+    minimum_succeeded_builds: 1
+  plan:
+  - in_parallel:
+    - get: buildpack-artifact
+      trigger: true
+    - get: buildpack-repo
+    - get: pipeline-tasks
+  - task: bump-buildpack
+    file: pipeline-tasks/bump-blob.yml
+    params:
+      CI_BOT_USER: ((bot-user))
+      CI_BOT_EMAIL: ((bot-email))
+      ACCESS_KEY_ID: ((bucket-access-key))
+      SECRET_KEY: ((bucket-secret-key))
+      BLOB_NAME: ((buildpack-blob-name))
+      BLOB_REGEX: ((buildpack-blob-regexp))
+    input_mapping:
+      blob-input: buildpack-artifact
+      repository-input: buildpack-repo
+    output_mapping:
+      repository-output: bumped-repository
+  - task: create-release
+    file: pipeline-tasks/create-release.yml
+    params:
+      CI_BOT_USER: ((bot-user))
+      CI_BOT_EMAIL: ((bot-email))
+      ACCESS_KEY_ID: ((bucket-access-key))
+      SECRET_KEY: ((bucket-secret-key))
+    input_mapping:
+      repository-input: bumped-repository
+      version-input: buildpack-artifact
+    output_mapping:
+      repository-output: final-repository
+  - put: buildpack-repo
+    params:
+      repository: final-repository
+      rebase: true
+  - put: bosh-release
+    params:
+      file: release-tarball/*.tgz
+  on_success:
+    put: notify
+    params:
+      alert_type: success
+      mode: concise
+      message_file: notification-output/message.txt
+  on_failure:
+    put: notify
+    params:
+      alert_type: failed
+      mode: concise
+      message: Failed building ((buildpack-blob-name)) Bosh release

--- a/high-pipelines/buildpacks/reconfigure-pipeline
+++ b/high-pipelines/buildpacks/reconfigure-pipeline
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Invalid number of parameters, requires the concourse target and the pipeline name"
+  exit 1
+fi
+
+if ! command -v fly > /dev/null 2>&1; then
+  echo "fly must be installed before running this script!"
+  exit 1
+fi
+
+pipelines_path=$(cd $(dirname $0) && pwd)
+concourse_target=$1
+pipeline_name=$2
+
+if [[ ! -f ${pipelines_path}/vars-${pipeline_name}.yml ]]; then
+  echo "no vars file exist for the ${pipeline_name} pipeline, looking for vars-${pipeline_name}.yml"
+  exit 1
+fi
+
+if [[ -f ${pipelines_path}/creds.yml ]]; then
+  FLY_EXTRA="-l ${pipelines_path}/creds.yml"
+fi
+
+echo "configuring the $pipeline_name pipeline..."
+
+fly -t ${concourse_target} set-pipeline \
+  -p ${pipeline_name} \
+  -c ${pipelines_path}/pipeline.yml \
+  -l ${pipelines_path}/vars-common.yml \
+  -l ${pipelines_path}/vars-${pipeline_name}.yml ${FLY_EXTRA}
+  
+fly -t ${concourse_target} unpause-pipeline \
+  -p ${pipeline_name} > /dev/null

--- a/high-pipelines/buildpacks/vars-common.yml
+++ b/high-pipelines/buildpacks/vars-common.yml
@@ -1,0 +1,12 @@
+# Pipeline common task repository and branch
+tasks-repository: <ENTER CONCOURSE-PIPELINES-TASK REPO>
+tasks-branch: master
+
+# Nexus location for fetch the cached buildpack and uploading the Bosh release
+nexus-url: "<ENTER NEXUS REPO>"
+nexus-debug: false
+nexus-repository: software
+# Where do we get the cached buildpack
+nexus-buildpack-group: /buildpacks
+# Where do we upload the buildpack Bosh release
+nexus-bosh-group: /bosh/release

--- a/high-pipelines/buildpacks/vars-staticfile-buildpack.yml
+++ b/high-pipelines/buildpacks/vars-staticfile-buildpack.yml
@@ -1,0 +1,6 @@
+nexus-buildpack-regexp: "buildpacks/staticfile_buildpack-cached-cflinuxfs3-v(.*).zip"
+nexus-bosh-regexp: "bosh/release/staticfile-buildpack-release-(.*).tgz"
+buildpack-git-repository: <ENTER STATICFILE BUILDPACK BOSH REPO>
+buildpack-git-branch: master
+buildpack-blob-name: staticfile-buildpack
+buildpack-blob-regexp: "staticfile-buildpack/staticfile_buildpack-cached-cflinuxfs3-v(.*).zip"


### PR DESCRIPTION
This pipeline can be reused for any buildpacks by simply creating a `vars-<buildpack>.yml` file and creating the pipeline with `reconfigure-pipeline`.

Fixed #85 