### PR TITLE
Pull all RabbitMQ independently

### DIFF
--- a/pipelines/rabbitmq.yml
+++ b/pipelines/rabbitmq.yml
@@ -85,11 +85,8 @@ jobs:
   plan:
   - in_parallel:
     - get: pipeline-tasks
-    - get: cf-rabbitmq-release
-      passed:
-        - mirror-rabbitmq-release
-      trigger: true
     - get: cf-rabbitmq-multitenant-broker-release
+      trigger: true
   - task: rename-release
     file: pipeline-tasks/rename-bosh-io-release.yml
     input_mapping:
@@ -121,11 +118,8 @@ jobs:
   plan:
   - in_parallel:
     - get: pipeline-tasks
-    - get: cf-rabbitmq-release
-      passed:
-        - mirror-rabbitmq-release
-      trigger: true
     - get: cf-rabbitmq-smoke-tests-release
+      trigger: true
   - task: rename-release
     file: pipeline-tasks/rename-bosh-io-release.yml
     input_mapping:
@@ -157,11 +151,8 @@ jobs:
   plan:
   - in_parallel:
     - get: pipeline-tasks
-    - get: cf-rabbitmq-release
-      passed:
-        - mirror-rabbitmq-release
-      trigger: true
     - get: cf-cli-release
+      trigger: true
   - task: rename-release
     file: pipeline-tasks/rename-bosh-io-release.yml
     input_mapping:


### PR DESCRIPTION
Used to only trigger artifacts mirror when the main RabbitMQ release was
released which would cause some to get pulled even if they weren't
updated.. Now all 4 releases will be pulled when they are released and
only when they are released.

Fixes: #131