### PR TITLE
Add pipeline for managing the postgres-cluster bosh release

### DIFF
--- a/credentials.yml.template
+++ b/credentials.yml.template
@@ -4,5 +4,9 @@ rsync_key: |
 $(awk '{printf "  %s\n", $0}' < ${rsyncPrivateKey})
 rsync_key_base64: $(base64 ${rsyncPrivateKey} | tr -d '\n')
 slack_hook: ${slackWebhook}
-slack_disabled: false
 github_access_token: ${githubToken}
+
+# Overrides from defaults from default_parameters.yml
+# slack_disabled: false
+# generate_release_drafts: false
+# concourse_env: breezeway

--- a/default_parameters.yml
+++ b/default_parameters.yml
@@ -1,0 +1,3 @@
+slack_disabled: false
+generate_release_drafts: false
+concourse_env: breezeway

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,20 @@ Use the `generate_credentials.sh` script to generate a credential file.
 
 Open the generated file and validate the content. If the content is correct run `ln -sf credentials_$(date +"%m%d%Y").yml credentials.yml`.
 
+#### Override default settings
+
+The generated credentials file contains some settings which can be overriden from the default values specified in `default_parameters.yml`.
+
+For instance on the AVA environment we would override the following, in this case the `generate_release_drafts` is quite important:
+
+```yml
+slack_disabled: true
+generate_release_drafts: true
+concourse_env: avalon
+```
+
+*In this case on AVA the `generate_release_drafts` is quite important to override to `true` since it is not used to generate actual release artifacts*
+
 ### Login to Concourse and set the Pipelines
 
 ```bash

--- a/docs/install-concourse.md
+++ b/docs/install-concourse.md
@@ -62,10 +62,10 @@ volumes:
 
 ## Run Docker Concourse
 
-### From `/data/scripts/concourse-docker` directory:
+### From `/data/scripts/concourse-docker` directory
 
 `docker-compose up -d`
 
-### From any directory:
+### From any directory
 
 `docker-compose -f /data/scripts/concourse-docker/docker-compose.yml up -d`

--- a/pipelines/postgres-cluster.yml
+++ b/pipelines/postgres-cluster.yml
@@ -1,0 +1,160 @@
+---
+resource_types:
+  - name: slack-notifier
+    type: docker-image
+    source:
+      repository: mockersf/concourse-slack-notifier
+  - name: rsync
+    type: docker-image
+    source:
+      repository: trecnoc/rsync-resource
+resources:
+  - name: pipeline-tasks
+    type: git
+    source:
+      uri: https://github.com/trecnoc/concourse-pipelines-tasks.git
+      branch: master
+  - name: postgres-cluster-repo
+    type: git
+    source:
+      uri: https://github.com/trecnoc/postgres-cluster-release.git
+      tag_filter: v*
+      username: ((github_access_token))
+      password: x-oauth-basic
+  - name: postgres-cluster-release
+    type: github-release
+    source:
+      owner: trecnoc
+      repository: postgres-cluster-release
+      access_token: ((github_access_token))
+      release: true
+      pre_release: false
+      drafts: ((generate_release_drafts))
+  - name: mirror
+    type: rsync
+    source:
+      server: ((rsync_server))
+      username: ((rsync_user))
+      private_key: ((rsync_key))
+      base_dir: /data/repo/bosh/release
+  - name: notify
+    type: slack-notifier
+    source:
+      url: ((slack_hook))
+      disabled: ((slack_disabled))
+jobs:
+  - name: build-postgres-cluster-release
+    build_log_retention:
+      days: 7
+      minimum_succeeded_builds: 1
+    plan:
+      - in_parallel:
+          - get: pipeline-tasks
+          - get: postgres-cluster-repo
+            trigger: true
+      - task: build-release
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: starkandwayne/concourse
+          inputs:
+            - name: postgres-cluster-repo
+          outputs:
+            - name: release
+            - name: notification
+          params:
+            DRAFT_RELEASE: ((generate_release_drafts))
+            CONCOURSE_ENV: ((concourse_env))
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                set -e
+                set -o pipefail
+
+                tag=$(cat postgres-cluster-repo/.git/ref)
+                version=${tag#v}
+
+                printf "Building postgres-cluster-release for version %s\n" ${version}
+
+                pushd postgres-cluster-repo >/dev/null
+
+                bosh create-release --final --version="${version}" --tarball ../release/postgres-cluster-release-${version}.tgz
+                cp release-notes.md ../release/release-notes.md
+
+                popd >/dev/null
+
+                release_name_suffix=""
+                if [[ "${DRAFT_RELEASE}" == "true" ]]; then
+                  release_name_suffix="-${CONCOURSE_ENV}"
+                fi               
+
+                cat << EOF > release/name.txt
+                ${tag}${release_name_suffix}
+                EOF
+
+                cat << EOF > release/tag.txt
+                ${tag}
+                EOF
+
+                cat << EOF > notification/message.txt
+                Successfully built version ${version} of the postgres-cluster bosh release
+                EOF
+      - put: postgres-cluster-release
+        params:
+          name: release/name.txt
+          tag: release/tag.txt
+          body: release/release-notes.md
+          globs:
+            - release/*.tgz
+    on_success:
+      put: notify
+      params:
+        alert_type: success
+        mode: concise
+        message_file: notification/message.txt
+    on_failure:
+      put: notify
+      params:
+        alert_type: failed
+        mode: normal
+  - name: mirror-postgres-cluster-release
+    build_log_retention:
+      days: 7
+      minimum_succeeded_builds: 1
+    plan:
+      - in_parallel:
+          - get: pipeline-tasks
+          - get: postgres-cluster-release
+            trigger: true
+      - task: copy-release
+        file: pipeline-tasks/copy-github-release.yml
+        input_mapping:
+          release-input: postgres-cluster-release
+        params:
+          SKIP_VERSION_SUBDIR: true
+          RELEASE_NOTE_PREFIX: "postgres-cluster-release"
+      - put: mirror
+        params:
+          sub_dir: artifacts
+      - task: generate-notification
+        file: pipeline-tasks/generate-mirrored-notification.yml
+        input_mapping:
+          content-input: postgres-cluster-release
+        params:
+          INPUT_TYPE: generic
+          LABEL: "postgres-cluster bosh release"
+    on_success:
+      put: notify
+      params:
+        alert_type: success
+        mode: concise
+        message_file: notification/message.txt
+    on_failure:
+      put: notify
+      params:
+        alert_type: failed
+        mode: normal

--- a/set_pipelines.sh
+++ b/set_pipelines.sh
@@ -4,6 +4,7 @@ set -e
 set -o pipefail
 
 CREDENTIAL_FILE=credentials.yml
+DEFAULT_PARAMETERS=default_parameters.yml
 
 if [[ "$#" -eq 1 ]]; then
   TARGET=$1
@@ -22,7 +23,7 @@ configure_pipeline() {
   CONFIG_FILE=$2
 
   printf "Setting pipeline: %s\n" ${NAME}
-  fly -t ${TARGET} set-pipeline -n -p ${NAME} -c ${CONFIG_FILE} --load-vars-from ${CREDENTIAL_FILE}
+  fly -t ${TARGET} set-pipeline -n -p ${NAME} -c ${CONFIG_FILE} --load-vars-from ${DEFAULT_PARAMETERS} --load-vars-from ${CREDENTIAL_FILE}
   fly -t ${TARGET} unpause-pipeline -p ${NAME} >/dev/null
 }
 
@@ -36,6 +37,7 @@ configure_pipeline logsearch pipelines/logsearch.yml
 configure_pipeline mattermost pipelines/mattermost.yml
 configure_pipeline minio pipelines/minio.yml
 configure_pipeline mysql pipelines/mysql.yml
+configure_pipeline postgres-cluster pipelines/postgres-cluster.yml
 configure_pipeline prometheus pipelines/prometheus.yml
 configure_pipeline rabbitmq pipelines/rabbitmq.yml
 configure_pipeline redis pipelines/redis.yml


### PR DESCRIPTION
Introduced default paramaters (default_parameters.yml) when running the
pipelines. These parameters contains values used on our main concourse
intallation and can be overriden in the credentials.yml file (generate
script updated also to account for these. The set_pipeline.sh script was
updated to load the content of that new file.

This allows us to use different values for some properties on the AVA
environment specifically in this commit it will allow us to use Github
releases and on AVA it will just create draft releases with a different
name.

Fixes: VITE-831