### PR TITLE
Mirror our promregator fork

### DIFF
--- a/pipelines/prometheus.yml
+++ b/pipelines/prometheus.yml
@@ -22,9 +22,10 @@ resources:
   - name: promregator
     type: github-release
     source:
-      owner: promregator
+      owner: trecnoc
       repository: promregator
       access_token: ((github_access_token))
+      pre_release: true
   - name: mirror
     type: rsync
     source:


### PR DESCRIPTION
@braunsonm now all we need to do is create a github release and add the jar file to it and it should get mirrored... Pre-releases included if you want to upload snapshots